### PR TITLE
Issue 15 - Adding tests for legacy support.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,14 +4,22 @@
 
 1. Related issue(s):
 
-  * [Issue x](https://github.com/neetjn/core-routing/issues/x) - Some issue.
+> * [Issue x](https://github.com/neetjn/core-routing/issues/x) - Some issue.
 
 2. Have you added test(s) for your patch? If not, why not?
 
+> TBD
+
 3. Can you provide an example of your patch in use?
 
+> TBD
+
 4. Is this a breaking change?
+
+> TBD
 
 #### Content
 
 Provide a short description about what you have changed:
+
+> TBD

--- a/__test__/router.legacy.test.js
+++ b/__test__/router.legacy.test.js
@@ -21,13 +21,6 @@ describe('Router (legacy support)', () => {
       href: `http://localhost/#!${NAVIGATED_ROUTE}`
     }
 
-    const EMPTY_ROUTE = '/'
-    const NAVIGATED_EMPTY_LOCATION_EVENT = {
-      path: EMPTY_ROUTE,
-      hash: `#!${EMPTY_ROUTE}`,
-      href: `http://localhost/#!${EMPTY_ROUTE}`
-    }
-
     const ctx = { }
 
     beforeEach(() => {

--- a/__test__/router.legacy.test.js
+++ b/__test__/router.legacy.test.js
@@ -1,10 +1,10 @@
 require('@testing-library/jest-dom/extend-expect')
 const Router = require('../dist/router.dev')
 
-describe('Router', () => {
+// TAG: issue-15 - https://github.com/neetjn/core-routing/issues/15
+describe('Router (legacy support)', () => {
     const navigate = route => {
       window.location.hash = `#!${route}`
-      window.dispatchEvent(new Event('popstate'))
     }
 
     const DEFAULT_ROUTE = '/home'
@@ -48,6 +48,10 @@ describe('Router', () => {
 
       navigate(DEFAULT_ROUTE)
 
+      // delete popstate handler in window
+      // should trigger legacy fallback
+      delete(window.onpopstate)
+
       ctx.router = new Router({
         client: {
           onStart(e) {
@@ -73,8 +77,7 @@ describe('Router', () => {
     it('should initialize as expected', () => {
       expect(ctx.router.running).toBeFalsy()
       expect(ctx.state.started.called).toBe(0)
-      // TAG: issue-15 - https://github.com/neetjn/core-routing/issues/15
-      expect(ctx.router.legacySupport).toBeFalsy()
+      expect(ctx.router.legacySupport).toBeTruthy()
     })
 
     it('should start as expected', () => {
@@ -98,6 +101,7 @@ describe('Router', () => {
       ctx.router.start()
       expect(ctx.state.navigated.called).toBe(0)
       navigate(NAVIGATED_ROUTE)
+      // TODO: left here, resolve navigation failure
       expect(ctx.state.navigated.called).toBe(1)
       expect(ctx.state.navigated.event.previous).toEqual(DEFAULT_LOCATION_EVENT)
       expect(ctx.state.navigated.event.location).toEqual(NAVIGATED_LOCATION_EVENT)

--- a/__test__/router.legacy.test.js
+++ b/__test__/router.legacy.test.js
@@ -96,29 +96,16 @@ describe('Router (legacy support)', () => {
       expect(ctx.state.stopped.event.location).toEqual(DEFAULT_LOCATION_EVENT)
     })
 
-    it('should handle navigations as expected', () => {
+    it('should handle navigations as expected', (done) => {
       expect(ctx.state.navigated.called).toBe(0)
       ctx.router.start()
       expect(ctx.state.navigated.called).toBe(0)
       navigate(NAVIGATED_ROUTE)
-      // TODO: left here, resolve navigation failure
-      expect(ctx.state.navigated.called).toBe(1)
-      expect(ctx.state.navigated.event.previous).toEqual(DEFAULT_LOCATION_EVENT)
-      expect(ctx.state.navigated.event.location).toEqual(NAVIGATED_LOCATION_EVENT)
-    })
-
-    // TAG: issue-18 - https://github.com/neetjn/core-routing/issues/18
-    it('should handle empty paths as expected', () => {
-      expect(ctx.state.navigated.called).toBe(0)
-      ctx.router.start()
-      expect(ctx.state.navigated.called).toBe(0)
-      navigate(EMPTY_ROUTE)
-      expect(ctx.state.navigated.called).toBe(1)
-      expect(ctx.state.navigated.event.previous).toEqual(DEFAULT_LOCATION_EVENT)
-      expect(ctx.state.navigated.event.location).toEqual(NAVIGATED_EMPTY_LOCATION_EVENT)
-      expect(ctx.state.navigated.event.$tools.match(
-        EMPTY_ROUTE,
-        ctx.state.navigated.event.location.path
-      )).toBeTruthy()
+      window.setTimeout(() => {
+        expect(ctx.state.navigated.called).toBe(1)
+        expect(ctx.state.navigated.event.previous).toEqual(DEFAULT_LOCATION_EVENT)
+        expect(ctx.state.navigated.event.location).toEqual(NAVIGATED_LOCATION_EVENT)
+        done()
+      }, ctx.router.config.intervals.listener)
     })
   })


### PR DESCRIPTION
### Answer the following depending on the type of change you want to merge

#### Code

1. Related issue(s):

>  * [Issue 15](https://github.com/neetjn/core-routing/issues/15) - Add test for legacy support.

2. Have you added test(s) for your patch? If not, why not?

> Yes.

3. Can you provide an example of your patch in use?

> TBD

4. Is this a breaking change?

> No.

#### Content

Provide a short description about what you have changed:

> I've provided tests to ensure the router functions as expected with legacy support for browsers w/o the HTML5 history api.